### PR TITLE
Do not process node_modules via Webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,5 +24,8 @@
     "typescript": "3.1.3",
     "webpack": "4.23.1",
     "webpack-cli": "3.1.2"
+  },
+  "devDependencies": {
+    "webpack-node-externals": "1.7.2"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,5 @@
 const { GraphQLCodegenPlugin } = require('graphql-codegen-webpack');
+const nodeExternals = require('webpack-node-externals');
 
 module.exports = {
   mode: 'development',
@@ -11,18 +12,14 @@ module.exports = {
   resolve: {
     extensions: ['.ts', '.ts', '.graphql', '.js', '.mjs'],
   },
+  externals: [nodeExternals()],
   plugins: [
     new GraphQLCodegenPlugin(),
   ],
   module: {
     rules: [
       { test: /\.ts$/, loader: 'ts-loader' },
-      { test: /\.graphql$/, loader: 'graphql-tag/loader' },
-      {
-        test: /\.mjs$/,
-        include: /node_modules/,
-        type: 'javascript/auto',
-      },
+      { test: /\.graphql$/, loader: 'graphql-tag/loader' }
     ],
   }
 };


### PR DESCRIPTION
We should mark `node_modules` as external for Webpack in order to avoid errors during their processing. There is no point in compiling the `node_modules` code for server platform into final bundle by Webpack, since the code is already compiled and can be used by `node` as is.